### PR TITLE
Update syslog.c

### DIFF
--- a/canix/syslog.c
+++ b/canix/syslog.c
@@ -78,9 +78,9 @@ void canix_syslog_P(uint8_t prio, const char *fmt, ...)
 			message.size = payload_counter;
 			payload_counter = 0;
 			canix_frame_send(&message);
+			canix_sleep_100th(1);
 		}
 
-		canix_sleep_100th(1);
 	}
 }
 


### PR DESCRIPTION
canix_sleep_100th(1); außerhalb der schleife verursacht abgehackte Syslog Meldungen. Bzw. diese sehen so aus als ob sie geteilt werden und dann in der falschen Reihenfolge ankommen.
Durch den Fix läuft es seit geraumer Zeit besser und ist stabil