### PR TITLE
hcanswd Option --mkdir 

### DIFF
--- a/hcanswd/main.cc
+++ b/hcanswd/main.cc
@@ -124,6 +124,9 @@ void handle_given_options (const po::parsed_options &options,
 	{
 		if (map.count("dir"))
 		{
+			bool mkdir = false;
+			if(map.count("mkdir"))
+				mkdir = true;
 			run_archive_mode(map["dir"].as<string>());
 		}
 		else
@@ -159,6 +162,7 @@ int main(int argc, char *argv[])
 			("archive-mode", "Archive mode logs to directory ")
 			("out,o", po::value<string>(), "standard mode: file to store data to")
 			("dir", po::value<string>(), "archive mode: directory to store data to")
+			("mkdir", "Create Directory when not present")
 			;
 
 		po::options_description config_file_options;


### PR DESCRIPTION
Option --mkdir eingebaut. Damit wird das Verzeichnis automatisch angelegt. Wichtig fuer die Speicherung auf der RAM Disk